### PR TITLE
create viewmodel compromisso

### DIFF
--- a/controller/compromisso.go
+++ b/controller/compromisso.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"go-api/model"
 	"go-api/usecase/compromisso"
+	"go-api/viewmodel"
 	"net/http"
-	"regexp"
 
 	"github.com/labstack/echo/v4"
 )
@@ -45,41 +45,26 @@ func (u *CompromissoController) CreateCompromisso(ctx echo.Context) error {
 
 }
 func (u *CompromissoController) UpdateParticipanteCompromisso(ctx echo.Context) error {
-	usuarioUUID := ctx.Param("uuid")
-	email, err := u.CompromissoUsecase.GetCompromissos(usuarioUUID)
-	if err != nil {
-		return ctx.JSON(http.StatusInternalServerError, err)
-	}
+	compromissoUUID := ctx.Param("uuid")
 
-	var updatecompromissos model.UpdateCompromisso
-	fmt.Printf("%v\n\n\n", updatecompromissos)
-
-	err = ctx.Bind(&updatecompromissos)
-
+	var updateParticipantesCompromissos viewmodel.UpdateParticipantesCompromisso
+	err := ctx.Bind(&updateParticipantesCompromissos)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, err)
 	}
-	updatecompromissos = email
 
-	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	nameRegex := `^[a-zA-Z\s]+$`
-	emailPattern, _ := regexp.Compile(emailRegex)
-	namePattern, _ := regexp.Compile(nameRegex)
-
-	if !emailPattern.MatchString(updatecompromissos.Email) {
-		return ctx.JSON(http.StatusBadRequest, err)
-	}
-	if !namePattern.MatchString(updatecompromissos.Nome) {
-		return ctx.JSON(http.StatusBadRequest, err)
+	fmt.Printf("%v\n\n\n", updateParticipantesCompromissos)
+	valid := updateParticipantesCompromissos.Validate()
+	if !valid {
+		ctx.JSON(http.StatusBadRequest, nil) // Arrumar para retornar erro
 	}
 
-	fmt.Printf("%v\n\n\n\n", updatecompromissos)
-	upCompromisso, err := u.CompromissoUsecase.GetCompromissos(updatecompromissos)
-
+	compromisso_atualizado, err := u.CompromissoUsecase.UpdateParticipantesCompromisso(compromissoUUID, updateParticipantesCompromissos.Emails)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, err)
 	}
-	fmt.Printf("%v\n\n", upCompromisso)
-	return ctx.JSON(http.StatusCreated, upCompromisso)
+
+	fmt.Printf("%v\n\n", compromisso_atualizado)
+	return ctx.JSON(http.StatusCreated, compromisso_atualizado) // Parsear para viewmodel
 
 }

--- a/model/compromisso.go
+++ b/model/compromisso.go
@@ -1,14 +1,13 @@
 package model
 
 type Compromisso struct {
-	Compromisso_id int     `json:"compromisso_id"`
-	Local_id       int     `json:"local_id"`
-	Categoria_id   int     `json:"categoria_id"`
-	Created_at     string  `json:"created_at"`
-	Updated_at     string  `json:"updated_at"`
-	Delete_at      *string `json:"delete_at"`
-	Horainicio     string  `json:"horainicio"`
-	Horafim        string  `json:"horafim"`
-	//Nome           string  `json:"nome"`
-	Participantes []Participantes
+	Compromisso_id int
+	Local_id       int
+	Categoria_id   int
+	Created_at     string
+	Updated_at     string
+	Delete_at      *string
+	Horainicio     string
+	Horafim        string
+	Participantes  []Participantes
 }

--- a/projeto/main.go
+++ b/projeto/main.go
@@ -53,6 +53,7 @@ func main() {
 	server.POST("/criarParticipante", ParticipantesController.CreateParticipante)
 	server.GET("/compromissos/:uuid", CompromissoController.GetCompromisso)
 	server.POST("/criarCompromisso", CompromissoController.CreateCompromisso)
+	server.PATCH("/compromissos/:uuid/participantes", CompromissoController.UpdateParticipanteCompromisso)
 
 	server.Logger.Fatal(server.Start(":8080"))
 

--- a/usecase/compromisso/compromisso_usecase.go
+++ b/usecase/compromisso/compromisso_usecase.go
@@ -74,9 +74,9 @@ func (cu *CompromissoUsecase) Resolverparticipantes(listacompromisso []model.Com
 	fmt.Println(compromissoscomparticipantes)
 	return compromissoscomparticipantes, nil
 }
-func (cu *CompromissoUsecase) UpdateParticipanteCompromisso(uuidcompromisso string, lista_emails_nova []model.Participantes) ([]model.Compromisso, error) {
+func (cu *CompromissoUsecase) UpdateParticipantesCompromisso(uuid_compromisso string, lista_emails_nova []string) ([]model.Compromisso, error) {
 	// Obtém a lista atual de compromissos
-	listacompromisso, err := cu.repository.GetCompromissoUsuario(uuidcompromisso)
+	listacompromisso, err := cu.repository.GetCompromissoUsuario(uuid_compromisso)
 	if err != nil {
 		return []model.Compromisso{}, err
 	} // Valida a lista de participantes e atualiza conforme necessário

--- a/viewmodel/compromisso.go
+++ b/viewmodel/compromisso.go
@@ -1,0 +1,42 @@
+package viewmodel
+
+import (
+	"regexp"
+)
+
+type InsertCompromisso struct {
+	Local_id     int    `json:"local_id"`
+	Categoria_id int    `json:"categoria_id"`
+	Horainicio   string `json:"horainicio"`
+	Horafim      string `json:"horafim"`
+}
+
+type GetCompromisso struct {
+	Compromisso_id int     `json:"compromisso_id"`
+	Local_id       int     `json:"local_id"`
+	Categoria_id   int     `json:"categoria_id"`
+	Created_at     string  `json:"created_at"`
+	Updated_at     string  `json:"updated_at"`
+	Delete_at      *string `json:"delete_at"`
+	Horainicio     string  `json:"horainicio"`
+	Horafim        string  `json:"horafim"`
+	//Participantes []Participantes
+}
+
+type UpdateParticipantesCompromisso struct {
+	Emails []string `json:"emails"`
+}
+
+func (vm UpdateParticipantesCompromisso) Validate() bool {
+	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+	emailPattern, _ := regexp.Compile(emailRegex)
+
+	for _, email := range vm.Emails {
+		if !emailPattern.MatchString(email) {
+			// Retornar erro ao inves de bool
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
- Criar rota patch para atualizar os participantes de um compromisso
- Adicionar camada de viewmodel para rotas de compromisso
 Migrar a validação de lista de emails para a viewmodel
- Ajustar parâmetros de entrada do método UpdateParticipantesCompromisso do UseCase de compromisso 